### PR TITLE
Openvpn logstash listen on TCP in addition to UDP

### DIFF
--- a/src/openvpn/Dockerfile
+++ b/src/openvpn/Dockerfile
@@ -19,6 +19,7 @@ FROM docker.elastic.co/logstash/logstash:7.1.1
 ###############
 
 EXPOSE 9910/udp
+EXPOSE 9910/tcp
 
 COPY logstash.conf /usr/share/logstash/config/logstash.conf
 

--- a/src/openvpn/logstash.conf
+++ b/src/openvpn/logstash.conf
@@ -2,6 +2,9 @@ input {
     udp {
         port => 9910
     }
+    tcp {
+        port => 9910
+    }
 }
 
 


### PR DESCRIPTION
This change let's the user of the container have more options for integrating into their environment by allowing either tcp or udp.

I made this change in our environment so it could more easily run in ECS behind and NLB, I thought it might be useful upstream.